### PR TITLE
fix: update entangled-node & threshold argument

### DIFF
--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -166,7 +166,7 @@
     "classnames": "2.2.6",
     "electron-settings": "3.2.0",
     "electron-updater": "4.0.14",
-    "entangled-node": "rihardsgravis/entangled-node#8e86e4c",
+    "entangled-node": "rihardsgravis/entangled-node#00ccb34",
     "hw-app-iota": "0.6.1",
     "i18next": "17.0.6",
     "iota.lib.js": "0.5.2",

--- a/src/desktop/src/libs/SeedStore/SeedStoreCore.js
+++ b/src/desktop/src/libs/SeedStore/SeedStoreCore.js
@@ -64,7 +64,7 @@ export default class SeedStoreCore {
         essenceLength = 486 * 4,
         count = 10 ** 8,
         procs = 0,
-        miningThreshold = 3 ** 40,
+        miningThreshold = 40,
     ) {
         return Electron.getBundleMinerFn()(
             Array.from(normalizedBundle),


### PR DESCRIPTION
# Description

- Updates `entangled-node` to include https://github.com/iotaledger/entangled/pull/1464
- Adjusts `miningThreshold` which is now expressed as security level


## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manually tested that `entangled-node` mines bundles with expected security level.

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
